### PR TITLE
Skip group discount calculations when not required

### DIFF
--- a/uobtheatre/bookings/models.py
+++ b/uobtheatre/bookings/models.py
@@ -274,10 +274,11 @@ class Booking(TimeStampedMixin, models.Model):
         Returns:
             int: price of the booking with discounts applied in penies
         """
-        return math.ceil(
-            self.get_best_discount_combination_with_price()[1]
-            * (1 - self.admin_discount_percentage)
-        )
+        if self.performance.has_group_discounts:
+            discounted_price = self.get_best_discount_combination_with_price()[1]
+        else:
+            discounted_price = self.tickets_price()
+        return math.ceil(discounted_price * (1 - self.admin_discount_percentage))
 
     def get_best_discount_combination_with_price(
         self,

--- a/uobtheatre/bookings/test/test_models.py
+++ b/uobtheatre/bookings/test/test_models.py
@@ -407,6 +407,18 @@ def test_misc_costs_value():
 
 
 @pytest.mark.django_db
+def test_subtotal_with_group_discounts():
+    performance = PerformanceFactory()
+    group_discount = DiscountFactory()
+    group_discount.performances.set([performance])
+    DiscountRequirementFactory(discount=group_discount)
+    DiscountRequirementFactory(discount=group_discount)
+    booking = BookingFactory(performance=performance)
+
+    assert booking.subtotal() == booking.get_best_discount_combination_with_price()[1]
+
+
+@pytest.mark.django_db
 def test_total():
     ValueMiscCostFactory(value=200)
     PercentageMiscCostFactory(percentage=0.1)

--- a/uobtheatre/productions/models.py
+++ b/uobtheatre/productions/models.py
@@ -355,6 +355,23 @@ class Performance(TimeStampedMixin, models.Model):
         """
         return self.tickets.filter(checked_in=False)
 
+    @property
+    def has_group_discounts(self) -> bool:
+        """
+        Returns true if any of the discounts for this production have more than
+        1 ticket in the requirements.
+
+        Returns:
+            bool: Whether the peformance has group discounts available.
+        """
+        return (
+            self.discounts.annotate(
+                number_of_tickets_required=Sum("requirements__number")
+            )
+            .filter(number_of_tickets_required__gt=1)
+            .exists()
+        )
+
     def total_capacity(self, seat_group=None):
         """Total capacity of the Performance.
 

--- a/uobtheatre/productions/test/test_models.py
+++ b/uobtheatre/productions/test/test_models.py
@@ -772,3 +772,27 @@ def test_qs_running_on():
         spanning_performance_1,
         spanning_performance_2,
     ]
+
+
+@pytest.mark.django_db
+def test_has_group_discounts():
+    performance = PerformanceFactory()
+    assert not performance.has_group_discounts
+
+    # Add a discount with no requirements
+    single_discount = DiscountFactory()
+    single_discount.performances.set([performance])
+    assert not performance.has_group_discounts
+
+    # Create a discount requirement
+    DiscountRequirementFactory(discount=single_discount)
+    assert not performance.has_group_discounts
+
+    # Create another single discount
+    double_discount = DiscountFactory()
+    double_discount.performances.set([performance])
+    DiscountRequirementFactory(discount=double_discount)
+    assert not performance.has_group_discounts
+
+    DiscountRequirementFactory(discount=double_discount)
+    assert performance.has_group_discounts


### PR DESCRIPTION
Speed up calculation of ticket price breakdown by skipping group discount calculation when performance has no group discounts