### PR TITLE
fix: Update booking target user

### DIFF
--- a/uobtheatre/bookings/admin.py
+++ b/uobtheatre/bookings/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.utils.html import format_html
 
 from uobtheatre.bookings.models import Booking, MiscCost, Ticket
 
@@ -21,14 +20,5 @@ class BookingAdmin(admin.ModelAdmin):
     """
 
     inlines = [SeatBookingInline]
-    list_display = ("reference", "view_price", "view_price_with_discount")
-
-    def view_price(self, booking):
-        return format_html("<p> {} </p>", booking.get_price())
-
-    def view_price_with_discount(self, booking):
-        return format_html("<p> {} </p>", booking.subtotal)
-
-    view_price.short_description = "Price"  # type: ignore
-
-    view_price_with_discount.short_description = "Discounted Price"  # type: ignore
+    readonly_fields = ("subtotal", "total")
+    list_display = ("reference",)

--- a/uobtheatre/bookings/models.py
+++ b/uobtheatre/bookings/models.py
@@ -452,6 +452,7 @@ class Booking(TimeStampedMixin, Payable, models.Model):
         """
         return sum(misc_cost.get_value(self) for misc_cost in MiscCost.objects.all())
 
+    @property
     def total(self) -> int:
         """The total cost of the Booking.
 
@@ -532,7 +533,7 @@ class Booking(TimeStampedMixin, Payable, models.Model):
         Returns:
             Payment: The payment created by the checkout (optional)
         """
-        payment = payment_method.pay(self.total(), self.misc_costs_value(), self)
+        payment = payment_method.pay(self.total, self.misc_costs_value(), self)
 
         # If a payment is created set the booking as paid
         if payment:

--- a/uobtheatre/bookings/test/test_models.py
+++ b/uobtheatre/bookings/test/test_models.py
@@ -505,7 +505,7 @@ def test_total():
     booking = BookingFactory()
     psg = PerformanceSeatingFactory(performance=booking.performance, price=1200)
     ticket = TicketFactory(booking=booking, seat_group=psg.seat_group)
-    assert ticket.booking.total() == 1520
+    assert ticket.booking.total == 1520
 
 
 @pytest.mark.django_db
@@ -524,7 +524,7 @@ def test_total_with_admin_discount(
     psg = PerformanceSeatingFactory(performance=booking.performance, price=1200)
     ticket = TicketFactory(booking=booking, seat_group=psg.seat_group)
     assert booking.misc_costs_value() == expected_misc_costs_value
-    assert ticket.booking.total() == expected_price
+    assert ticket.booking.total == expected_price
 
 
 @pytest.mark.django_db

--- a/uobtheatre/bookings/test/test_schema.py
+++ b/uobtheatre/bookings/test/test_schema.py
@@ -294,7 +294,7 @@ def test_bookings_price_break_down(gql_client):  # pylint: disable=too-many-loca
         "discountsValue": booking.discount_value(),
         "subtotalPrice": booking.subtotal,
         "miscCostsValue": int(booking.misc_costs_value()),
-        "totalPrice": booking.total(),
+        "totalPrice": booking.total,
         "ticketsDiscountedPrice": booking.subtotal,
     }
 

--- a/uobtheatre/productions/test/test_schema.py
+++ b/uobtheatre/productions/test/test_schema.py
@@ -960,7 +960,7 @@ def test_production_and_performance_sales_breakdowns(gql_client):
     )
     perf_seat_group = PerformanceSeatingFactory(performance=performance, price=100)
     TicketFactory(booking=booking, seat_group=perf_seat_group.seat_group)
-    PaymentFactory(pay_object=booking, value=booking.total())
+    PaymentFactory(pay_object=booking, value=booking.total)
 
     request = """
         {

--- a/uobtheatre/reports/test/test_reports.py
+++ b/uobtheatre/reports/test/test_reports.py
@@ -117,7 +117,7 @@ def create_fixtures():
 
     payment_1 = PaymentFactory(
         pay_object=booking_1,
-        value=booking_1.total(),
+        value=booking_1.total,
         provider=payment_methods.SquarePOS.__name__,
         provider_payment_id="square_id",
         app_fee=booking_1.misc_costs_value(),
@@ -128,14 +128,14 @@ def create_fixtures():
 
     payment_2 = PaymentFactory(
         pay_object=booking_2,
-        value=booking_2.total(),
+        value=booking_2.total,
         provider="CASH",
         app_fee=booking_2.misc_costs_value(),
     )
     payment_2.created_at = "2021-09-05T12:00:01"
     payment_2.save()
 
-    payment_3 = PaymentFactory(pay_object=booking_3, value=booking_3.total())
+    payment_3 = PaymentFactory(pay_object=booking_3, value=booking_3.total)
     payment_3.created_at = "2021-09-08T12:00:01"
     payment_3.save()
 


### PR DESCRIPTION
When updating the target user on an existing booking, if that user already has a draft booking for that performance, an error gets thrown. This will delete the previous booking