### PR TITLE
feat: Email Ticket Links

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,8 @@
 
 	"extensions": [
 		"ms-python.python",
-		"njpwerner.autodocstring"
+		"njpwerner.autodocstring",
+		"eamodio.gitlens"
 	],
 
 	"remoteEnv": {

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = autoslug,dateutil,django,django_filters,django_tiptap,environ,factory,graphene,graphene_django,graphql,graphql_auth,graphql_relay,guardian,pytest,rest_framework,shortuuid,square,storages,xlsxwriter
+known_third_party = autoslug,dateutil,django,django_filters,django_tiptap,environ,factory,graphene,graphene_django,graphql,graphql_auth,graphql_relay,guardian,pytest,pytz,rest_framework,shortuuid,square,storages,timezonefinder,xlsxwriter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,4 +84,5 @@ repos:
             djangorestframework,
             django_tiptap,
             django_inlinecss,
+            timezonefinder
           ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,9 +12,6 @@ django-filter==21.1
 # Something to do with images
 Pillow>=8.1.2
 
-# timezone package
-pytz==2021.3
-
 # Cors
 django-cors-headers==3.10.0
 
@@ -65,3 +62,7 @@ whitenoise==5.3.0  # https://github.com/evansd/whitenoise
 #=== Email ===#
 django-anymail[amazon_ses]==8.4  # https://github.com/anymail/django-anymail
 django-inlinecss==0.3.0
+
+#=== Timezones ===#
+timezonefinder==5.2.0
+pytz==2021.3

--- a/uobtheatre/addresses/models.py
+++ b/uobtheatre/addresses/models.py
@@ -1,4 +1,8 @@
+from functools import cached_property
+
+import pytz
 from django.db import models
+from timezonefinder import TimezoneFinder
 
 
 class Address(models.Model):
@@ -11,6 +15,15 @@ class Address(models.Model):
     postcode = models.CharField(max_length=9)
     latitude = models.FloatField(blank=True, null=True)
     longitude = models.FloatField(blank=True, null=True)
+
+    @cached_property
+    def timezone(self):
+        """Returns the timezone at the address"""
+        if not self.latitude or not self.longitude:
+            return pytz.UTC
+
+        finder = TimezoneFinder()
+        return pytz.timezone(finder.timezone_at(lat=self.latitude, lng=self.longitude))
 
     def __str__(self):
         return f"{self.building_name + ', ' if self.building_name else ''}{self.building_number + ', ' if self.building_number else ''}{self.street}, {self.city}, {self.postcode}"

--- a/uobtheatre/addresses/test/test_models.py
+++ b/uobtheatre/addresses/test/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+import pytz
 
 from uobtheatre.addresses.test.factories import AddressFactory
 
@@ -31,3 +32,15 @@ def test_address_to_string(building_name, building_number, output):
     )
 
     assert str(address) == output
+
+
+@pytest.mark.django_db
+def test_timezone_without_coordinates():
+    address = AddressFactory(latitude=None, longitude=None)
+    assert address.timezone == pytz.UTC
+
+
+@pytest.mark.django_db
+def test_timezone_with_coordinates():
+    address = AddressFactory(latitude=51.45662710361974, longitude=-2.613237959640326)
+    assert address.timezone.zone == "Europe/London"

--- a/uobtheatre/bookings/models.py
+++ b/uobtheatre/bookings/models.py
@@ -588,13 +588,14 @@ class Booking(TimeStampedMixin, Payable, models.Model):
 
         composer.line(
             (
-                "This event opens at %s for a %s start. Please bring your tickets (printed or on your phone) or your booking reference (<strong>%s</strong>)."
+                "This event opens at %s for a %s start (please note that %s might not be your current timezone). Please bring your tickets (printed or on your phone) or your booking reference (<strong>%s</strong>)."
                 if self.user.status.verified
-                else "This event opens at %s for a %s start. Please bring your booking reference (<strong>%s</strong>)."
+                else "This event opens at %s for a %s start (please note that %s might not be your current timezone). Please bring your booking reference (<strong>%s</strong>)."
             )
             % (
                 self.performance.doors_open.strftime("%d %B %Y %H:%M %Z"),
                 self.performance.start.strftime("%H:%M %Z"),
+                self.performance.start.strftime("%Z"),
                 self.reference,
             )
         )

--- a/uobtheatre/bookings/models.py
+++ b/uobtheatre/bookings/models.py
@@ -9,6 +9,7 @@ from django.db.models.functions import Cast
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.functional import cached_property
+from graphql_relay.node.node import to_global_id
 
 from uobtheatre.discounts.models import ConcessionType, DiscountCombination
 from uobtheatre.mail.composer import MailComposer
@@ -554,6 +555,20 @@ class Booking(TimeStampedMixin, Payable, models.Model):
         self.save()
         self.send_confirmation_email()
 
+    @property
+    def web_tickets_path(self):
+        """Generates the path to the public tickets display page on the frontend for this booking"""
+        query_string = "?" + "&".join(
+            [
+                f"performanceID={to_global_id('PerformanceNode', self.performance.id)}",
+            ]
+            + [
+                f"ticketID={to_global_id('TicketNode', id)}"
+                for id in self.tickets.values_list("id", flat=True)
+            ]
+        )
+        return f"/user/booking/{self.reference}/tickets" + query_string
+
     def send_confirmation_email(self):
         """
         Send email confirmation which includes a link to the booking.
@@ -584,10 +599,10 @@ class Booking(TimeStampedMixin, Payable, models.Model):
             )
         )
 
+        composer.action(self.web_tickets_path, "View Tickets")
+
         if self.user.status.verified:
-            composer.action(
-                "/user/booking/%s" % self.reference, "View Tickets & Booking"
-            )
+            composer.action("/user/booking/%s" % self.reference, "View Booking")
 
         payment = self.payments.first()
         # If this booking includes a payment, we will include details of this payment as a reciept

--- a/uobtheatre/bookings/models.py
+++ b/uobtheatre/bookings/models.py
@@ -588,14 +588,17 @@ class Booking(TimeStampedMixin, Payable, models.Model):
 
         composer.line(
             (
-                "This event opens at %s for a %s start (please note that %s might not be your current timezone). Please bring your tickets (printed or on your phone) or your booking reference (<strong>%s</strong>)."
+                "This event opens at %s for a %s start. Please bring your tickets (printed or on your phone) or your booking reference (<strong>%s</strong>)."
                 if self.user.status.verified
-                else "This event opens at %s for a %s start (please note that %s might not be your current timezone). Please bring your booking reference (<strong>%s</strong>)."
+                else "This event opens at %s for a %s start. Please bring your booking reference (<strong>%s</strong>)."
             )
             % (
-                self.performance.doors_open.strftime("%d %B %Y %H:%M %Z"),
-                self.performance.start.strftime("%H:%M %Z"),
-                self.performance.start.strftime("%Z"),
+                self.performance.doors_open.astimezone(
+                    self.performance.venue.address.timezone
+                ).strftime("%d %B %Y %H:%M %Z"),
+                self.performance.start.astimezone(
+                    self.performance.venue.address.timezone
+                ).strftime("%H:%M %Z"),
                 self.reference,
             )
         )

--- a/uobtheatre/bookings/models.py
+++ b/uobtheatre/bookings/models.py
@@ -1,5 +1,6 @@
 import math
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from urllib.parse import urlencode
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.postgres.aggregates import BoolAnd
@@ -558,16 +559,14 @@ class Booking(TimeStampedMixin, Payable, models.Model):
     @property
     def web_tickets_path(self):
         """Generates the path to the public tickets display page on the frontend for this booking"""
-        query_string = "?" + "&".join(
-            [
-                f"performanceID={to_global_id('PerformanceNode', self.performance.id)}",
-            ]
-            + [
-                f"ticketID={to_global_id('TicketNode', id)}"
+        params = {
+            "performanceID": to_global_id("PerformanceNode", self.performance.id),
+            "ticketID": [
+                to_global_id("TicketNode", id)
                 for id in self.tickets.values_list("id", flat=True)
-            ]
-        )
-        return f"/user/booking/{self.reference}/tickets" + query_string
+            ],
+        }
+        return f"/user/booking/{self.reference}/tickets?" + urlencode(params, True)
 
     def send_confirmation_email(self):
         """

--- a/uobtheatre/bookings/test/test_models.py
+++ b/uobtheatre/bookings/test/test_models.py
@@ -1090,9 +1090,15 @@ def test_send_confirmation_email(mailoutbox, with_payment, provider_payment_id):
     assert len(mailoutbox) == 1
     email = mailoutbox[0]
     assert email.subject == "Your booking is confirmed!"
-    assert "https://example.com/user/booking/abc" in email.body
+    assert "View Booking (https://example.com/user/booking/abc" in email.body
+    assert (
+        "View Tickets (https://example.com%s" % booking.web_tickets_path in email.body
+    )
     assert "Legally Ginger" in email.body
-    assert "opens at 20 October 2021 18:15 UTC for a 19:15 UTC start" in email.body
+    assert (
+        "opens at 20 October 2021 18:15 UTC for a 19:15 UTC start (please note that UTC might not be your current timezone)"
+        in email.body
+    )
     if with_payment:
         assert "Payment Information" in email.body
         assert "10.00 GBP" in email.body
@@ -1138,9 +1144,15 @@ def test_send_confirmation_email_for_anonymous(mailoutbox):
     assert len(mailoutbox) == 1
     email = mailoutbox[0]
     assert email.subject == "Your booking is confirmed!"
-    assert "https://example.com/user/booking/abc" not in email.body
+    assert "View Booking (https://example.com/user/booking/abc" not in email.body
+    assert (
+        "View Tickets (https://example.com%s" % booking.web_tickets_path in email.body
+    )
     assert "Legally Ginger" in email.body
-    assert "opens at 20 October 2021 18:15 UTC for a 19:15 UTC start" in email.body
+    assert (
+        "opens at 20 October 2021 18:15 UTC for a 19:15 UTC start (please note that UTC might not be your current timezone)"
+        in email.body
+    )
     assert "reference (abc)" in email.body
 
 

--- a/uobtheatre/bookings/test/test_models.py
+++ b/uobtheatre/bookings/test/test_models.py
@@ -2,6 +2,7 @@
 import datetime
 import math
 from unittest.mock import patch
+from urllib.parse import quote_plus
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -1159,8 +1160,9 @@ def test_send_confirmation_email_for_anonymous(mailoutbox):
 def test_web_tickets_path_property():
     booking = BookingFactory(reference="abcd1234")
     ticket_ids = [
-        to_global_id("TicketNode", ticket.id)
-        for ticket in [TicketFactory(booking=booking) for _ in range(3)]
+        # Get URL safe global ids
+        quote_plus((to_global_id("TicketNode", ticket.id)))
+        for ticket in [TicketFactory(booking=booking, id=i) for i in range(3)]
     ]
     performance_id = to_global_id("PerformanceNode", booking.performance.id)
 

--- a/uobtheatre/bookings/test/test_models.py
+++ b/uobtheatre/bookings/test/test_models.py
@@ -9,6 +9,7 @@ from django.db.utils import IntegrityError
 from django.utils import timezone
 from graphql_relay.node.node import to_global_id
 
+from uobtheatre.addresses.test.factories import AddressFactory
 from uobtheatre.bookings.models import Booking, MiscCost, Ticket
 from uobtheatre.bookings.test.factories import (
     BookingFactory,
@@ -1051,18 +1052,20 @@ def test_complete():
 )
 def test_send_confirmation_email(mailoutbox, with_payment, provider_payment_id):
     production = ProductionFactory(name="Legally Ginger")
+    venue = VenueFactory(address=AddressFactory(latitude=51.4, longitude=-2.61))
     performance = PerformanceFactory(
+        venue=venue,
         doors_open=datetime.datetime(
-            day=20,
-            month=10,
+            day=4,
+            month=11,
             year=2021,
             hour=18,
             minute=15,
             tzinfo=timezone.get_current_timezone(),
         ),
         start=datetime.datetime(
-            day=20,
-            month=10,
+            day=4,
+            month=11,
             year=2021,
             hour=19,
             minute=15,
@@ -1095,10 +1098,7 @@ def test_send_confirmation_email(mailoutbox, with_payment, provider_payment_id):
         "View Tickets (https://example.com%s" % booking.web_tickets_path in email.body
     )
     assert "Legally Ginger" in email.body
-    assert (
-        "opens at 20 October 2021 18:15 UTC for a 19:15 UTC start (please note that UTC might not be your current timezone)"
-        in email.body
-    )
+    assert "opens at 04 November 2021 18:15 GMT for a 19:15 GMT start" in email.body
     if with_payment:
         assert "Payment Information" in email.body
         assert "10.00 GBP" in email.body
@@ -1114,6 +1114,7 @@ def test_send_confirmation_email(mailoutbox, with_payment, provider_payment_id):
 @pytest.mark.django_db
 def test_send_confirmation_email_for_anonymous(mailoutbox):
     production = ProductionFactory(name="Legally Ginger")
+    venue = VenueFactory(address=AddressFactory(latitude=51.4, longitude=-2.61))
     performance = PerformanceFactory(
         doors_open=datetime.datetime(
             day=20,
@@ -1132,6 +1133,7 @@ def test_send_confirmation_email_for_anonymous(mailoutbox):
             tzinfo=timezone.get_current_timezone(),
         ),
         production=production,
+        venue=venue,
     )
     booking = BookingFactory(
         status=Booking.BookingStatus.IN_PROGRESS,
@@ -1149,10 +1151,7 @@ def test_send_confirmation_email_for_anonymous(mailoutbox):
         "View Tickets (https://example.com%s" % booking.web_tickets_path in email.body
     )
     assert "Legally Ginger" in email.body
-    assert (
-        "opens at 20 October 2021 18:15 UTC for a 19:15 UTC start (please note that UTC might not be your current timezone)"
-        in email.body
-    )
+    assert "opens at 20 October 2021 19:15 BST for a 20:15 BST start" in email.body
     assert "reference (abc)" in email.body
 
 

--- a/uobtheatre/reports/reports.py
+++ b/uobtheatre/reports/reports.py
@@ -208,7 +208,7 @@ class OutstandingSocietyPayments(Report):
             [
                 "Society ID",
                 "Society Name",
-                "Total Ammount Due",
+                "Total Amount Due",
             ],
         )
 

--- a/uobtheatre/reports/views.py
+++ b/uobtheatre/reports/views.py
@@ -65,8 +65,8 @@ def period_totals(request, start_time, end_time):
         "Period Totals Report",
         [
             "This report provides summaries and totals of payments taken and recorded.",
-            "Totals are calcualted by summing the payments (which are positive in the chase of a charge, or negative for a refund).",
-            "Totals are inclusive of any costs and fees that are charged to the society. Hence, these figures should not be used to calculate account transfers to societies.",
+            "Totals are calcualted by summing the payments (which are positive in the case of a charge, or negative for a refund).",
+            "Totals are the amount collected, without any costs and fees that are charged to the society or the payment deducted. Hence, these figures should not be used to calculate account transfers to societies.",
             "All currency is PENCE (i.e. 100 = £1.00)",
         ],
         [


### PR DESCRIPTION
Based on new frontend features implemented in https://github.com/BristolSTA/uobtheatre-web/pull/214, we can now generate links to allow users to view their tickets without being logged in.

This PR:
- Generates this link and inserts it into the booking email
- Adds methods to guess the event's timezone based on its venue's address. This timezone is then used in the email generator for the booking email to give the user localised times and reduce confusion


Closes #274