### PR TITLE
fix: Performance Capacity Calculation

### DIFF
--- a/uobtheatre/productions/models.py
+++ b/uobtheatre/productions/models.py
@@ -332,11 +332,15 @@ class Performance(
             int: The capacity of the show
         """
 
-        return (
-            min(self.capacity, self.total_seat_group_capacity())
-            if self.capacity
-            else self.total_seat_group_capacity()
-        )
+        limiting_capacities = [
+            self.total_seat_group_capacity(),
+            self.venue.internal_capacity,
+        ]
+
+        if self.capacity:
+            limiting_capacities.append(self.capacity)
+
+        return min(limiting_capacities)
 
     def total_tickets_sold(self, **kwargs):
         """The number of tickets sold for the performance


### PR DESCRIPTION
Fix the current calculation by factoring in the internal capacity on a venue as a limiting factor on the number of tickets able to be sold at a venue

Fixes #393 