### PR TITLE
fix: Fix filtering expired bookings

### DIFF
--- a/uobtheatre/bookings/models.py
+++ b/uobtheatre/bookings/models.py
@@ -18,6 +18,7 @@ from uobtheatre.payments.models import Transaction
 from uobtheatre.payments.payables import Payable, PayableQuerySet
 from uobtheatre.productions.models import Performance, Production
 from uobtheatre.users.models import User
+from uobtheatre.utils.filters import filter_passes_on_model
 from uobtheatre.utils.models import TimeStampedMixin
 from uobtheatre.utils.utils import combinations, create_short_uuid
 from uobtheatre.venues.models import Seat, SeatGroup
@@ -152,7 +153,7 @@ class BookingQuerySet(PayableQuerySet):
 
         return query_set
 
-    def expired(self, bool_val=False) -> QuerySet:
+    def expired(self, bool_val=True) -> QuerySet:
         """Bookings that are not expired will be returned
 
         Args:
@@ -163,8 +164,12 @@ class BookingQuerySet(PayableQuerySet):
             QuerySet: the filtered queryset
         """
         if bool_val:
-            return self.exclude(status="PAID").filter(expires_at__lt=timezone.now())
-        return self.filter(Q(status="PAID") | Q(expires_at__gt=timezone.now()))
+            return self.filter(
+                status=Payable.Status.IN_PROGRESS, expires_at__lt=timezone.now()
+            )
+        return self.filter(
+            ~Q(status=Payable.Status.IN_PROGRESS) | Q(expires_at__gt=timezone.now())
+        )
 
 
 def generate_expires_at():
@@ -606,12 +611,7 @@ class Booking(TimeStampedMixin, Payable):
     @property
     def is_reservation_expired(self):
         """Returns whether the booking is considered expired"""
-
-        return (
-            self.status == Payable.Status.IN_PROGRESS
-            and self.expires_at
-            and timezone.now() > self.expires_at
-        )
+        return filter_passes_on_model(self, lambda qs: qs.expired())
 
     @property
     def can_be_refunded(self):

--- a/uobtheatre/bookings/test/test_models.py
+++ b/uobtheatre/bookings/test/test_models.py
@@ -998,6 +998,11 @@ def test_booking_expiration():
     assert expired_booking.is_reservation_expired
 
     expired_booking.status = Payable.Status.PAID
+    expired_booking.save()
+    assert not expired_booking.is_reservation_expired
+
+    expired_booking.status = Payable.Status.CANCELLED
+    expired_booking.save()
     assert not expired_booking.is_reservation_expired
 
 

--- a/uobtheatre/payments/payables.py
+++ b/uobtheatre/payments/payables.py
@@ -12,7 +12,7 @@ from uobtheatre.payments.exceptions import CantBeRefundedException
 from uobtheatre.payments.models import Transaction
 from uobtheatre.users.models import User
 from uobtheatre.utils.filters import filter_passes_on_model
-from uobtheatre.utils.models import AbstractModelMeta
+from uobtheatre.utils.models import AbstractModelMeta, BaseModel
 
 
 class PayableQuerySet(QuerySet):
@@ -33,7 +33,7 @@ class PayableQuerySet(QuerySet):
         ).filter(transaction_totals=0)
 
 
-class Payable(models.Model, metaclass=AbstractModelMeta):  # type: ignore
+class Payable(BaseModel, metaclass=AbstractModelMeta):  # type: ignore
     """
     An model which can be paid for
     """

--- a/uobtheatre/productions/test/test_mutations.py
+++ b/uobtheatre/productions/test/test_mutations.py
@@ -909,8 +909,8 @@ def test_performance_mutation_create_with_no_production(gql_client):
 @pytest.mark.parametrize("with_permission", [True, False])
 def test_performance_mutation_update(gql_client, with_permission):
     performance = PerformanceFactory(
-        doors_open=datetime(day=9, month=11, year=2021),
-        end=datetime(day=11, month=11, year=2021),
+        doors_open=datetime(day=9, month=11, year=2021, tzinfo=pytz.UTC),
+        end=datetime(day=11, month=11, year=2021, tzinfo=pytz.UTC),
     )
     request = """
         mutation {


### PR DESCRIPTION
Previously: the expired filter was dependant on the booking status being not paid as an escape (i.e. if the booking was cancelled and the expires_at was in the past, it would count as expired)
Now: expired filter dependant on being in progress, and expires_at being in the past.

Also changed to use new filter-first approach to creating computed properties, to reduce duplicate across the codebase