### PR TITLE
fix: Modify Concession Type Ability With Multiple Performances

### DIFF
--- a/uobtheatre/discounts/abilities.py
+++ b/uobtheatre/discounts/abilities.py
@@ -30,7 +30,7 @@ class ModifyConcessionType(Ability):
         performances = Performance.objects.filter(discounts__in=discounts)
         unique_productions_using_it = Production.objects.filter(
             performances__in=performances
-        )
+        ).distinct()
 
         if not unique_productions_using_it.count() == 1:
             return False

--- a/uobtheatre/discounts/test/test_abilities.py
+++ b/uobtheatre/discounts/test/test_abilities.py
@@ -77,7 +77,12 @@ def test_modify_concession_type_ability_when_only_on_owned_production():
     concession_type = ConcessionTypeFactory()
 
     dis_1 = DiscountFactory()
-    dis_1.performances.set([PerformanceFactory(production=production)])
+    dis_1.performances.set(
+        [
+            PerformanceFactory(production=production),
+            PerformanceFactory(production=production),
+        ]
+    )
 
     DiscountRequirementFactory(discount=dis_1, concession_type=concession_type)
 


### PR DESCRIPTION
Previously...
- The production query in the aforementioned ability can return the same model more than once
- 
Now...
- Added a distinct query to ensure only unique models given back
- Updated the test to actually test that workflow