### PR TITLE
fix: User Schema Security

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -223,19 +223,12 @@ type EnumNode {
 }
 
 type ExtendedUserNode {
-  lastLogin: DateTime
-  isSuperuser: Boolean!
   firstName: String!
   lastName: String!
-  isStaff: Boolean!
-  isActive: Boolean!
   dateJoined: DateTime!
   id: String
   email: String!
-  societies(offset: Int, before: String, after: String, first: Int, last: Int, id: ID, name: String, slug: String, userHasPermission: String): SocietyNodeConnection!
   bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, reference: String, user: ID, creator: ID, performance: ID, adminDiscountPercentage: Float, expiresAt: DateTime, id: ID, statusIn: [String], search: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
-  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, reference: String, user: ID, creator: ID, performance: ID, adminDiscountPercentage: Float, expiresAt: DateTime, id: ID, statusIn: [String], search: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
-  password: String!
   pk: Int
   archived: Boolean
   verified: Boolean

--- a/uobtheatre/users/schema.py
+++ b/uobtheatre/users/schema.py
@@ -27,6 +27,16 @@ class ExtendedUserNode(schema.UserNode):
 
     class Meta:
         model = User
+        fields = (
+            "id",
+            "email",
+            "first_name",
+            "last_name",
+            "date_joined",
+            "bookings",
+            "createdBookings",
+            "permissions",
+        )
 
 
 class AuthMutation(graphene.ObjectType):

--- a/uobtheatre/users/schema.py
+++ b/uobtheatre/users/schema.py
@@ -34,7 +34,7 @@ class ExtendedUserNode(schema.UserNode):
             "last_name",
             "date_joined",
             "bookings",
-            "createdBookings",
+            "created_bookings",
             "permissions",
         )
 

--- a/uobtheatre/users/test/test_schema.py
+++ b/uobtheatre/users/test/test_schema.py
@@ -18,8 +18,8 @@ def test_user_schema(gql_client):
     bookings = [BookingFactory(user=user) for i in range(4)]
 
     # Create an irrelevant user with some bookings
-    # irrelevant_user = UserFactory()
-    # _ = [BookingFactory(user=irrelevant_user) for i in range(4)]
+    irrelevant_user = UserFactory()
+    _ = [BookingFactory(user=irrelevant_user) for i in range(4)]
 
     response = gql_client.execute(
         """
@@ -28,8 +28,6 @@ def test_user_schema(gql_client):
             firstName
             lastName
             email
-            isStaff
-            dateJoined
             id
             bookings {
               edges {
@@ -50,8 +48,6 @@ def test_user_schema(gql_client):
                 "firstName": user.first_name,
                 "lastName": user.last_name,
                 "email": user.email,
-                "isStaff": user.is_staff,
-                "dateJoined": user.date_joined.isoformat(),
                 "id": to_global_id("UserNode", user.id),
                 "bookings": {
                     "edges": [


### PR DESCRIPTION
- User schema is a bit exposed atm. If you are able to see another user node (e.g. on a booking or list of assignedUsers) you can see all of their details + relationships
- Need to guard these relationships so that only they can see them (plus permissions with good reason)