### PR TITLE
feat: Square SCA

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -311,7 +311,7 @@ type Mutation {
   generateReport(endTime: DateTime, name: String!, options: [ReportOption], startTime: DateTime): GenerateReport
   createBooking(adminDiscountPercentage: Float, performanceId: IdInputField, targetUserEmail: String, tickets: [CreateTicketInput]): CreateBooking
   updateBooking(adminDiscountPercentage: Float, bookingId: IdInputField, targetUserEmail: String, tickets: [UpdateTicketInput]): UpdateBooking
-  payBooking(bookingId: IdInputField!, deviceId: String, idempotencyKey: String, nonce: String, paymentProvider: PaymentMethod, price: Int!): PayBooking
+  payBooking(bookingId: IdInputField!, deviceId: String, idempotencyKey: String, nonce: String, paymentProvider: PaymentMethod, price: Int!, verifyToken: String): PayBooking
   checkInBooking(bookingReference: String!, performanceId: IdInputField!, tickets: [TicketIDInput]!): CheckInBooking
   uncheckInBooking(bookingReference: String!, performanceId: IdInputField!, tickets: [TicketIDInput]!): UnCheckInBooking
 }

--- a/uobtheatre/bookings/mutations.py
+++ b/uobtheatre/bookings/mutations.py
@@ -389,6 +389,7 @@ class PayBooking(AuthRequiredMixin, SafeMutation):
         )
         device_id = graphene.String(required=False)
         idempotency_key = graphene.String(required=False)
+        verify_token = graphene.String(required=False)
 
     @classmethod
     def resolve_mutation(  # pylint: disable=too-many-arguments, too-many-branches
@@ -401,6 +402,7 @@ class PayBooking(AuthRequiredMixin, SafeMutation):
         payment_provider=SquareOnline.name,
         device_id=None,
         idempotency_key=None,
+        verify_token=None,
     ):
 
         # Get the performance and if it doesn't exist throw an error
@@ -468,7 +470,7 @@ class PayBooking(AuthRequiredMixin, SafeMutation):
                     field="nonce",
                     code="missing_required",
                 )
-            payment_method = SquareOnline(nonce, idempotency_key)
+            payment_method = SquareOnline(nonce, idempotency_key, verify_token)
         elif payment_provider == SquarePOS.name:
             if not device_id:
                 raise GQLException(

--- a/uobtheatre/payments/transaction_providers.py
+++ b/uobtheatre/payments/transaction_providers.py
@@ -530,7 +530,9 @@ class SquareOnline(PaymentProvider, SquarePaymentMethod):
     def refund_providers(cls):
         return (SquareRefund(idempotency_key=str(uuid4())),)
 
-    def __init__(self, nonce: str, idempotency_key: str) -> None:
+    def __init__(
+        self, nonce: str, idempotency_key: str, verify_token: str = None
+    ) -> None:
         """
         Args:
             idempotency_key (str): This value is as unique indicator of
@@ -540,9 +542,11 @@ class SquareOnline(PaymentProvider, SquarePaymentMethod):
             nonce (str): The nonce is a reference to the completed payment
                 form on the front-end. This allows square to determine the
                 payment details to use.
+            verify_token(str): The verify token is used as part of 3D Secure verification, and is optional.
         """
         self.nonce = nonce
         self.idempotency_key = idempotency_key
+        self.verify_token = verify_token
         super().__init__()
 
     def pay(
@@ -569,6 +573,9 @@ class SquareOnline(PaymentProvider, SquarePaymentMethod):
             "amount_money": {"amount": value, "currency": "GBP"},
             "reference_id": pay_object.payment_reference_id,
         }
+        if self.verify_token:
+            body["verification_token"] = self.verify_token
+
         response = self.client.payments.create_payment(body)
         self._handle_response_failure(response)
 


### PR DESCRIPTION
We get a lot of cards declining because the card company wants Strong Customer Authentication (SCA).
This PR allows us to support that.

See https://developer.squareup.com/docs/sca-overview