### PR TITLE
repo: Fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
     - black >= 22.3.0
     - isort >= 5.10.1
     - pylint >= 2.13.0
-    - django-stubs >= 1.10.1
+    - django-stubs == 1.10.0
     - types-python-dateutil==2.8.10
     - pytest >= 6.2.2
     - pytest-sugar >= 0.9.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
     - black >= 22.3.0
     - isort >= 5.10.1
     - pylint >= 2.13.0
-    - django-stubs >= 1.9.0
+    - django-stubs >= 1.10.1
     - types-python-dateutil==2.8.10
     - pytest >= 6.2.2
     - pytest-sugar >= 0.9.4

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -11,7 +11,7 @@ pylint >= 2.14.0 # Linting
 
 # mypy stuff
 mypy >= 0.910 # Type checking
-django-stubs >= 1.10.0
+django-stubs == 1.10.0
 types-python-dateutil==2.8.17
 
 # testing


### PR DESCRIPTION
Bump stubs version used in pre commit to fix CI

Can un-fix stubs version once https://github.com/typeddjango/django-stubs/pull/1030 is merged (probably)