### PR TITLE
Add a production filter to the bookings() query

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -274,8 +274,8 @@ type ExtendedUserNode {
   dateJoined: DateTime!
   id: String
   email: String!
-  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
   pk: Int
   archived: Boolean
   verified: Boolean
@@ -474,7 +474,7 @@ type PerformanceNode implements Node {
   seatGroups(offset: Int, before: String, after: String, first: Int, last: Int): SeatGroupNodeConnection!
   capacity: Int
   discounts(offset: Int, before: String, after: String, first: Int, last: Int, group: Boolean, id: ID): DiscountNodeConnection!
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
   capacityRemaining: Int
   ticketOptions: [PerformanceSeatGroupNode]
   minSeatPrice: Int
@@ -665,7 +665,7 @@ input ProductionWarning {
 type Query {
   images: [ImageNode]
   paymentDevices(paymentProvider: PaymentProvider, paired: Boolean): [SquarePaymentDevice]
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection
   me: ExtendedUserNode
   societies(offset: Int, before: String, after: String, first: Int, last: Int, id: ID, name: String, slug: String, userHasPermission: String): SocietyNodeConnection
   society(slug: String!): SocietyNode
@@ -935,8 +935,8 @@ type UserNode implements Node {
   id: ID!
   email: String!
   societies(offset: Int, before: String, after: String, first: Int, last: Int, id: ID, name: String, slug: String, userHasPermission: String): SocietyNodeConnection!
-  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
   ticketsCheckedInByUser(offset: Int, before: String, after: String, first: Int, last: Int): TicketNodeConnection!
   pk: Int
   archived: Boolean

--- a/schema.graphql
+++ b/schema.graphql
@@ -274,8 +274,8 @@ type ExtendedUserNode {
   dateJoined: DateTime!
   id: String
   email: String!
-  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
   pk: Int
   archived: Boolean
   verified: Boolean
@@ -474,7 +474,7 @@ type PerformanceNode implements Node {
   seatGroups(offset: Int, before: String, after: String, first: Int, last: Int): SeatGroupNodeConnection!
   capacity: Int
   discounts(offset: Int, before: String, after: String, first: Int, last: Int, group: Boolean, id: ID): DiscountNodeConnection!
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
   capacityRemaining: Int
   ticketOptions: [PerformanceSeatGroupNode]
   minSeatPrice: Int
@@ -665,7 +665,7 @@ input ProductionWarning {
 type Query {
   images: [ImageNode]
   paymentDevices(paymentProvider: PaymentProvider, paired: Boolean): [SquarePaymentDevice]
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection
   me: ExtendedUserNode
   societies(offset: Int, before: String, after: String, first: Int, last: Int, id: ID, name: String, slug: String, userHasPermission: String): SocietyNodeConnection
   society(slug: String!): SocietyNode
@@ -935,8 +935,8 @@ type UserNode implements Node {
   id: ID!
   email: String!
   societies(offset: Int, before: String, after: String, first: Int, last: Int, id: ID, name: String, slug: String, userHasPermission: String): SocietyNodeConnection!
-  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, productionSlug: String, performanceId: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
   ticketsCheckedInByUser(offset: Int, before: String, after: String, first: Int, last: Int): TicketNodeConnection!
   pk: Int
   archived: Boolean

--- a/schema.graphql
+++ b/schema.graphql
@@ -274,8 +274,8 @@ type ExtendedUserNode {
   dateJoined: DateTime!
   id: String
   email: String!
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
-  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
   pk: Int
   archived: Boolean
   verified: Boolean
@@ -474,7 +474,7 @@ type PerformanceNode implements Node {
   seatGroups(offset: Int, before: String, after: String, first: Int, last: Int): SeatGroupNodeConnection!
   capacity: Int
   discounts(offset: Int, before: String, after: String, first: Int, last: Int, group: Boolean, id: ID): DiscountNodeConnection!
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
   capacityRemaining: Int
   ticketOptions: [PerformanceSeatGroupNode]
   minSeatPrice: Int
@@ -665,7 +665,7 @@ input ProductionWarning {
 type Query {
   images: [ImageNode]
   paymentDevices(paymentProvider: PaymentProvider, paired: Boolean): [SquarePaymentDevice]
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection
   me: ExtendedUserNode
   societies(offset: Int, before: String, after: String, first: Int, last: Int, id: ID, name: String, slug: String, userHasPermission: String): SocietyNodeConnection
   society(slug: String!): SocietyNode
@@ -935,8 +935,8 @@ type UserNode implements Node {
   id: ID!
   email: String!
   societies(offset: Int, before: String, after: String, first: Int, last: Int, id: ID, name: String, slug: String, userHasPermission: String): SocietyNodeConnection!
-  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
-  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, creator: ID, reference: String, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  createdBookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
+  bookings(offset: Int, before: String, after: String, first: Int, last: Int, createdAt: DateTime, updatedAt: DateTime, status: String, user: ID, reference: String, creator: ID, performance: ID, adminDiscountPercentage: Float, accessibilityInfo: String, expiresAt: DateTime, id: ID, statusIn: [String], search: String, productionSearch: String, checkedIn: Boolean, active: Boolean, expired: Boolean, orderBy: String): BookingNodeConnection!
   ticketsCheckedInByUser(offset: Int, before: String, after: String, first: Int, last: Int): TicketNodeConnection!
   pk: Int
   archived: Boolean

--- a/uobtheatre/bookings/schema.py
+++ b/uobtheatre/bookings/schema.py
@@ -255,9 +255,7 @@ class BookingFilter(FilterSet):
         Returns:
             Queryset: Filtered booking queryset.
         """
-        query = Q()
-        for word in value.split():
-            query = query | Q(performance__production__name__icontains=word)
+        query = Q() | Q(performance__production__name__icontains=value)
         return queryset.filter(query)
 
     def filter_checked_in(self, queryset, _, value):

--- a/uobtheatre/bookings/schema.py
+++ b/uobtheatre/bookings/schema.py
@@ -192,6 +192,9 @@ class BookingFilter(FilterSet):
 
     Restricts BookingNode to only return Bookings owned by the User. Adds
     ordering filter for created_at.
+
+    Also adds filtering for bookings based on the name of its associated
+    production.
     """
 
     status_in = django_filters.MultipleChoiceFilter(
@@ -199,6 +202,11 @@ class BookingFilter(FilterSet):
     )
 
     search = django_filters.CharFilter(method="search_bookings", label="Search")
+
+    production_search = django_filters.CharFilter(
+        method="production_search_bookings", label="Production Search"
+    )
+
     checked_in = django_filters.BooleanFilter(
         method="filter_checked_in", label="Checked In"
     )
@@ -234,6 +242,22 @@ class BookingFilter(FilterSet):
                 | Q(user__email__icontains=word)
                 | Q(reference__icontains=word)
             )
+        return queryset.filter(query)
+
+    def production_search_bookings(self, queryset, _, value):
+        """
+        Given a query string, searches through the bookings using the name of each associated production
+
+        Args:
+            queryset (Queryset): The bookings queryset.
+            value (str): The search query.
+
+        Returns:
+            Queryset: Filtered booking queryset.
+        """
+        query = Q()
+        for word in value.split():
+            query = query | Q(performance__production__name__icontains=word)
         return queryset.filter(query)
 
     def filter_checked_in(self, queryset, _, value):

--- a/uobtheatre/bookings/test/test_schema.py
+++ b/uobtheatre/bookings/test/test_schema.py
@@ -861,7 +861,7 @@ def test_bookings_slug_filter(slug, expected_filtered_bookings, gql_client):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "id, expected_filtered_bookings",
+    "performance_id, expected_filtered_bookings",
     [
         ("", [1, 2, 3]),  # Empty should return all, but not error
         (to_global_id("PerformanceNode", 10), [1]),  # Check basic query
@@ -871,12 +871,14 @@ def test_bookings_slug_filter(slug, expected_filtered_bookings, gql_client):
         (to_global_id("PerformanceNode", 30), []),
     ],
 )
-def test_bookings_performance_id(id, expected_filtered_bookings, gql_client):
+def test_bookings_performance_id(
+    performance_id, expected_filtered_bookings, gql_client
+):
 
     performance_1 = PerformanceFactory(id=10)
     performance_2 = PerformanceFactory(id=20)
 
-    b1 = BookingFactory(id=1, performance=performance_1)  # id: 10
+    BookingFactory(id=1, performance=performance_1)  # id: 10
     BookingFactory(id=2, performance=performance_2)  # id: 20
     BookingFactory(id=3, performance=performance_2)  # id: 20
 
@@ -892,7 +894,7 @@ def test_bookings_performance_id(id, expected_filtered_bookings, gql_client):
                 }
             }
         """
-        % id
+        % performance_id
     )
 
     boxoffice_perm = Permission.objects.get(codename="boxoffice")

--- a/uobtheatre/bookings/test/test_schema.py
+++ b/uobtheatre/bookings/test/test_schema.py
@@ -797,6 +797,66 @@ def test_bookings_search(search_phrase, expected_filtered_bookings, gql_client):
     assert len(response_bookings_id) == len(expected_booking_ids)
     assert set(response_bookings_id) == set(expected_booking_ids)
 
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "search_phrase, expected_filtered_bookings",
+    [
+        ("prod", [1,2,3]), # Check case-insensitivity
+        ("prod ", [1,2,3]), # Check *final* spaces *are* stripped
+        ("prod2", [3]), # Check spaces within prod name *aren't* ignored
+        ("prod 2", [2]), # Check spaces *aren't* treated as an OR, and also
+                         # check *internal* spaces *aren't* stripped
+        ("def", []), # Check actually filtering
+        ("", [1,2,3]), # Empty string should return all
+        ("aces", [2,3]) # Check matches all the way to the end; doesn't need
+                        # full word
+    ],
+)
+def test_bookings_productions_search(search_phrase, expected_filtered_bookings,
+                          gql_client):
+
+    prod1 = ProductionFactory(name="Prod1")
+    prod2 = ProductionFactory(name="prod 2 spaces")
+    prod3 = ProductionFactory(name="prod2spaces")
+
+    BookingFactory(id=1, reference="abc123",
+                   performance=PerformanceFactory(production=prod1))
+    BookingFactory(id=2, reference="abcdef",
+                   performance=PerformanceFactory(production=prod2))
+    BookingFactory(id=3, reference="ghijkl",
+                   performance=PerformanceFactory(production=prod3))
+
+    request = (
+            """
+            query {
+                bookings(productionSearch:"%s") {
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
+            }
+        """
+            % search_phrase
+    )
+
+    boxoffice_perm = Permission.objects.get(codename="boxoffice")
+    gql_client.login().user.user_permissions.add(boxoffice_perm)
+
+    response = gql_client.execute(request)
+
+    response_bookings_id = [
+        node["node"]["id"] for node in response["data"]["bookings"]["edges"]
+    ]
+    expected_booking_ids = [
+        to_global_id("BookingNode", booking_id)
+        for booking_id in expected_filtered_bookings
+    ]
+
+    assert len(response_bookings_id) == len(expected_booking_ids)
+    assert set(response_bookings_id) == set(expected_booking_ids)
+
 
 @pytest.mark.django_db
 def test_bookings_qs(gql_client):

--- a/uobtheatre/productions/migrations/0027_production_production_alert.py
+++ b/uobtheatre/productions/migrations/0027_production_production_alert.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('productions', '0026_auto_20221210_2056'),
+        ("productions", "0026_auto_20221210_2056"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='production',
-            name='production_alert',
+            model_name="production",
+            name="production_alert",
             field=models.TextField(blank=True, null=True),
         ),
     ]

--- a/uobtheatre/venues/test/test_models.py
+++ b/uobtheatre/venues/test/test_models.py
@@ -27,7 +27,9 @@ def test_venue_productions():
     production_2 = ProductionFactory()
 
     PerformanceFactory(production=production_1, venue=venue1)
-    PerformanceFactory(production=production_1, venue=venue1) # Catching productions being duplicated by .fliter() when there are multiple performance in the same venue
+    PerformanceFactory(
+        production=production_1, venue=venue1
+    )  # Catching productions being duplicated by .fliter() when there are multiple performance in the same venue
     PerformanceFactory(production=production_1, venue=venue2)
     PerformanceFactory(production=production_2, venue=venue2)
 


### PR DESCRIPTION
### What?

- This adds three filters to a `bookings` query.
  1. Based on the `name` of a production linked to each booking.
      - This filter is **whitespace sensitive**, so that a query for e.g. `"A Show"` would only match `"A Show"` and **not** `"A" || "Show"`.

  2. Based on the `slug` of a production linked to each booking. This must match exactly.

  4. Based on the `performanceId` of a performance linked to each booking. This must also match exactly.
      - This ID is in base64 format, and converted to the corresponding numeric ID within the query.

- This also adds tests for the various new filters.

### Why?

- This is used by the global bookings page in the admin part of the Web repo. (See [this PR](https://github.com/BristolSTA/uobtheatre-web/pull/375)).

### Notes

- We should consider if we want the first filter just to search the production `name`, or if we want it to search the `slug` or anything else as well.

