### PR TITLE
fix: Allow those with permission to approve productions to reject them too

### DIFF
--- a/uobtheatre/productions/mutations.py
+++ b/uobtheatre/productions/mutations.py
@@ -78,10 +78,9 @@ class SetProductionStatus(AuthRequiredMixin, SafeMutation):
             ):
                 return
 
-        # If they have permission to approve and they are tyring to approve a
-        # pending.
+        # If they have permission to approve they can either approve or reject a pending production
         if (
-            update_status == Production.Status.APPROVED
+            update_status in [Production.Status.APPROVED, Production.Status.DRAFT]
             and production.status == Production.Status.PENDING
             and user.has_perm("productions.approve_production", production)
         ):

--- a/uobtheatre/productions/test/test_mutations.py
+++ b/uobtheatre/productions/test/test_mutations.py
@@ -412,6 +412,14 @@ def test_production_mutation_update_by_local_id(gql_client):
             Production.Status.APPROVED,
             True,
         ),
+        # Someone who can approve can reject pending
+        (
+            ["productions.approve_production"],
+            False,
+            Production.Status.PENDING,
+            Production.Status.DRAFT,
+            True,
+        ),
         # Someone who can approve cannot do other things
         (
             ["productions.approve_production"],
@@ -420,7 +428,7 @@ def test_production_mutation_update_by_local_id(gql_client):
             Production.Status.PUBLISHED,
             False,
         ),
-        # Fincance can close
+        # Finance can close
         (
             ["reports.finance_reports"],
             False,


### PR DESCRIPTION
A very simple fix to resolve #822, and to add a test to cover the scenario.