### PR TITLE
deps: 1.2.5 Dependency Bump

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -65,7 +65,7 @@ squareup>=9.0.0.20210226
 #=== Logging ===#
 
 sentry-sdk==2.17.0
-whitenoise==6.7.0  # https://github.com/evansd/whitenoise
+whitenoise==6.8.1  # https://github.com/evansd/whitenoise
 
 #=== Email ===#
 django-anymail[amazon_ses]==11.0.1  # https://github.com/anymail/django-anymail

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -65,7 +65,7 @@ squareup>=9.0.0.20210226
 #=== Logging ===#
 
 sentry-sdk==2.17.0
-whitenoise==6.8.1  # https://github.com/evansd/whitenoise
+whitenoise==6.8.2  # https://github.com/evansd/whitenoise
 
 #=== Email ===#
 django-anymail[amazon_ses]==11.0.1  # https://github.com/anymail/django-anymail

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -64,7 +64,7 @@ squareup>=9.0.0.20210226
 
 #=== Logging ===#
 
-sentry-sdk==2.17.0
+sentry-sdk==2.18.0
 whitenoise==6.8.2  # https://github.com/evansd/whitenoise
 
 #=== Email ===#

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -23,7 +23,7 @@ pytest-django >= 0.2.0
 pytest-factoryboy >= 2.1.0
 coveralls >= 3.0.1
 factory-boy==3.3.1
-faker==30.8.2; python_version >= '3.6'
+faker==32.1.0; python_version >= '3.6'
 
 # Unsure
 jedi==0.19.2; python_version >= '3.6'

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -26,4 +26,4 @@ factory-boy==3.3.1
 faker==30.8.2; python_version >= '3.6'
 
 # Unsure
-jedi==0.19.1; python_version >= '3.6'
+jedi==0.19.2; python_version >= '3.6'

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -23,7 +23,7 @@ pytest-django >= 0.2.0
 pytest-factoryboy >= 2.1.0
 coveralls >= 3.0.1
 factory-boy==3.3.1
-faker==32.1.0; python_version >= '3.6'
+faker==33.0.0; python_version >= '3.6'
 
 # Unsure
 jedi==0.19.2; python_version >= '3.6'

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -23,7 +23,7 @@ pytest-django >= 0.2.0
 pytest-factoryboy >= 2.1.0
 coveralls >= 3.0.1
 factory-boy==3.3.1
-faker==30.8.1; python_version >= '3.6'
+faker==30.8.2; python_version >= '3.6'
 
 # Unsure
 jedi==0.19.1; python_version >= '3.6'


### PR DESCRIPTION
## Description

Dependency version bumps for v1.2.5. With this version dependency bumps are being moved to the first PR after a new version, rather than the last before a version, to allow any errors to be caught on staging & during development time.
