### PR TITLE
fix: Async Refunds & Square Webhooks

### DIFF
--- a/uobtheatre/bookings/admin.py
+++ b/uobtheatre/bookings/admin.py
@@ -128,10 +128,16 @@ class BookingAdmin(DangerousAdminConfirmMixin, admin.ModelAdmin):
                 request, f"{num_refunded} bookings have had refunds requested"
             )
 
-            refund_type = "Provider and UOB Theatre fee-accommodating" if (
-                preserve_provider_fees and preserve_app_fees
-            ) else "Provider fee-accommodating" if preserve_provider_fees else (
-                "UOB Theatre fee-accommodating" if preserve_app_fees else "Full"
+            refund_type = (
+                "Provider and UOB Theatre fee-accommodating"
+                if (preserve_provider_fees and preserve_app_fees)
+                else (
+                    "Provider fee-accommodating"
+                    if preserve_provider_fees
+                    else (
+                        "UOB Theatre fee-accommodating" if preserve_app_fees else "Full"
+                    )
+                )
             )
 
             mail = payable_refund_initiated_email(

--- a/uobtheatre/bookings/admin.py
+++ b/uobtheatre/bookings/admin.py
@@ -128,8 +128,14 @@ class BookingAdmin(DangerousAdminConfirmMixin, admin.ModelAdmin):
                 request, f"{num_refunded} bookings have had refunds requested"
             )
 
+            refund_type = "Provider and UOB Theatre fee-accommodating" if (
+                preserve_provider_fees and preserve_app_fees
+            ) else "Provider fee-accommodating" if preserve_provider_fees else (
+                "UOB Theatre fee-accommodating" if preserve_app_fees else "Full"
+            )
+
             mail = payable_refund_initiated_email(
-                request.user, refunded_bookings, "Full"
+                request.user, refunded_bookings, refund_type
             )
             mail_admins(
                 "Booking Refunds Initiated",

--- a/uobtheatre/payments/models.py
+++ b/uobtheatre/payments/models.py
@@ -260,12 +260,16 @@ class Transaction(TimeStampedMixin, BaseModel):
 
         return True
 
-    def async_refund(self):
+    def async_refund(self, preserve_provider_fees=True, preserve_app_fees=False):
         """
         Create "refund_payment" task to refund the payment. The task queue the
         refund method.
         """
-        refund_payment.delay(self.pk)
+        refund_payment.delay(
+            self.pk,
+            preserve_provider_fees=preserve_provider_fees,
+            preserve_app_fees=preserve_app_fees,
+        )
 
     def refund(
         self,

--- a/uobtheatre/payments/payables.py
+++ b/uobtheatre/payments/payables.py
@@ -196,9 +196,15 @@ class Payable(BaseModel):  # type: ignore
 
         for payment in self.transactions.filter(type=Transaction.Type.PAYMENT).all():  # type: ignore
             (
-                payment.async_refund()
+                payment.async_refund(
+                    preserve_provider_fees=preserve_provider_fees,
+                    preserve_app_fees=preserve_app_fees,
+                )
                 if do_async
-                else payment.refund(preserve_provider_fees, preserve_app_fees)
+                else payment.refund(
+                    preserve_provider_fees=preserve_provider_fees,
+                    preserve_app_fees=preserve_app_fees,
+                )
             )
 
         if send_admin_email:

--- a/uobtheatre/payments/tasks.py
+++ b/uobtheatre/payments/tasks.py
@@ -22,11 +22,19 @@ class RefundTask(BaseTask, abc.ABC):
 
 
 @app.task(base=RefundTask, throws=(CantBeRefundedException,))
-def refund_payment(payment_pk: int):
+def refund_payment(
+    payment_pk: int,
+    preserve_provider_fees: bool = True,
+    preserve_app_fees: bool = False,
+):
+    """Refund a payment automatically"""
     from uobtheatre.payments.models import Transaction
 
     payment = Transaction.objects.get(pk=payment_pk)
-    payment.refund()
+    payment.refund(
+        preserve_provider_fees=preserve_provider_fees,
+        preserve_app_fees=preserve_app_fees,
+    )
 
 
 @app.task(base=RefundTask, throws=(CantBeRefundedException,))

--- a/uobtheatre/payments/test/test_models.py
+++ b/uobtheatre/payments/test/test_models.py
@@ -281,7 +281,9 @@ def test_async_refund():
     transaction = TransactionFactory(id=45)
     with patch.object(refund_payment, "delay") as delay_mock:
         transaction.async_refund()
-        delay_mock.assert_called_once_with(45)
+        delay_mock.assert_called_once_with(
+            45, preserve_provider_fees=True, preserve_app_fees=False
+        )
 
 
 @pytest.mark.django_db

--- a/uobtheatre/payments/test/test_payables.py
+++ b/uobtheatre/payments/test/test_payables.py
@@ -354,12 +354,9 @@ def test_payable_refund(mailoutbox, can_be_refunded, send_email, do_async):
 
         assert mock.call_count == (2 if can_be_refunded else 0)
         assert len(mailoutbox) == (1 if can_be_refunded and send_email else 0)
-        if can_be_refunded and not do_async:
+        if can_be_refunded:
             mock.assert_any_call(payment_1, True, False)
             mock.assert_any_call(payment_2, True, False)
-        elif can_be_refunded:
-            mock.assert_any_call(payment_1)
-            mock.assert_any_call(payment_2)
 
 
 @pytest.mark.django_db

--- a/uobtheatre/payments/test/test_tasks.py
+++ b/uobtheatre/payments/test/test_tasks.py
@@ -39,7 +39,9 @@ def test_refund_payment_task():
     transaction = TransactionFactory(id=123)
     with patch("uobtheatre.payments.models.Transaction.refund", autospec=True) as mock:
         refund_payment(123)
-    mock.assert_called_once_with(transaction)
+    mock.assert_called_once_with(
+        transaction, preserve_provider_fees=True, preserve_app_fees=False
+    )
 
 
 @pytest.mark.django_db

--- a/uobtheatre/productions/mutations.py
+++ b/uobtheatre/productions/mutations.py
@@ -192,6 +192,7 @@ class ProductionMutation(SafeFormMutation, AuthRequiredMixin):
         info.context.user.assign_perm("view_production", response.production)
         info.context.user.assign_perm("view_bookings", response.production)
         info.context.user.assign_perm("change_production", response.production)
+        info.context.user.assign_perm("comp_tickets", response.production)
         info.context.user.assign_perm("sales", response.production)
         info.context.user.assign_perm("boxoffice", response.production)
 


### PR DESCRIPTION
I made an oversight on my partial refunds PR and missed including fees-accomodating refunds in async refunds (our primary type), so this is a fix for that!

Also, when Square informs us a refund has been completed (via webhook), the booking is now marked as `Refunded` at the same time the transaction is completed.