### PR TITLE
feat: Add User-Friendly Payment Error Messages

### DIFF
--- a/uobtheatre/utils/exceptions.py
+++ b/uobtheatre/utils/exceptions.py
@@ -246,13 +246,14 @@ class SquareException(GQLException):
             "TRANSACTION_LIMIT": "The card issuer has determined the payment amount is either too high or too low.",
             "BAD_EXPIRATION": "The card expiration date is either missing or incorrectly formatted.",
             "CARD_DECLINED_VERIFICATION_REQUIRED": "The payment card was declined with a request for additional verification.",
-            "CHIP_INSERTION_REQUIRED": "The card issuer requires the card to be inserted into a chip reader."
+            "CHIP_INSERTION_REQUIRED": "The card issuer requires the card to be inserted into a chip reader.",
         }
 
-        def get_user_readable_error_message(error: Error) -> str:
-            if error.code in passthrough_error_categories:
-                return user_readable_error_details.get(error.code, "There was an issue processing your payment (%s)" % error.detail)
-            return error.detail
+        def get_user_readable_error_message(error_code: Optional[str]) -> str:
+            return user_readable_error_details.get(
+                str(error_code),
+                "There was an issue processing your payment (%s)" % error_code,
+            )
 
         error = (
             api_error.errors[0]
@@ -261,7 +262,7 @@ class SquareException(GQLException):
         )
         message = (
             (
-                get_user_readable_error_message(error)
+                get_user_readable_error_message(error.code)
                 if error.category in passthrough_error_categories
                 else "There was an issue processing your payment (%s)"
                 % error.code

--- a/uobtheatre/utils/exceptions.py
+++ b/uobtheatre/utils/exceptions.py
@@ -232,21 +232,21 @@ class SquareException(GQLException):
         ]
         # Turn common Square errors into user-friendly messages
         user_readable_error_details = {
-            "ADDRESS_VERIFICATION_FAILURE": "The card issuer declined the request because the postal code is invalid.",
-            "CARD_EXPIRED": "The card issuer declined the request because the card is expired.",
-            "CVV_FAILURE": "The card issuer declined the request because the CVV value is invalid.",
-            "EXPIRATION_FAILURE": "The card expiration date is either invalid or indicates that the card is expired.",
+            "ADDRESS_VERIFICATION_FAILURE": "Your card details appear to be incorrect. Please check your details and try again.",
+            "CARD_EXPIRED": "Your card details appear to be incorrect. Please check your details and try again.",
+            "CVV_FAILURE": "Your card details appear to be incorrect. Please check your details and try again.",
+            "EXPIRATION_FAILURE": "Your card details appear to be incorrect. Please check your details and try again.",
+            "INVALID_EXPIRATION": "Your card details appear to be incorrect. Please check your details and try again.",
+            "INVALID_CARD": "Your card details appear to be incorrect. Please check your details and try again.",
+            "INVALID_PIN": "Your card details appear to be incorrect. Please check your details and try again.",
+            "PAN_FAILURE": "Your card details appear to be incorrect. Please check your details and try again.",
+            "BAD_EXPIRATION": "Your card details appear to be incorrect. Please check your details and try again.",
             "GENERIC_DECLINE": "Square received a decline without any additional information. If the payment information seems correct, contact your card issuer to ask for more information.",
             "INSUFFICIENT_FUNDS": "The funding source has insufficient funds to cover the payment.",
-            "INVALID_EXPIRATION": "The expiration date for the payment card is invalid. For example, it indicates a date in the past.",
-            "INVALID_CARD": "The credit card cannot be validated based on the provided details.",
             "INVALID_PHONE_NUMBER": "The provided phone number is invalid.",
-            "INVALID_PIN": "The card issuer declined the request because the PIN is invalid.",
-            "PAN_FAILURE": "The specified card number is invalid. For example, it is of incorrect length or is incorrectly formatted.",
             "TRANSACTION_LIMIT": "The card issuer has determined the payment amount is either too high or too low.",
-            "BAD_EXPIRATION": "The card expiration date is either missing or incorrectly formatted.",
-            "CARD_DECLINED_VERIFICATION_REQUIRED": "The payment card was declined with a request for additional verification.",
-            "CHIP_INSERTION_REQUIRED": "The card issuer requires the card to be inserted into a chip reader.",
+            "CARD_DECLINED_VERIFICATION_REQUIRED": "The payment card was declined with a request for additional verification Square cannot process.",
+            "CHIP_INSERTION_REQUIRED": "The card issuer requires the card to be inserted into a chip reader, which Square cannot process.",
         }
 
         def get_user_readable_error_message(error_code: Optional[str]) -> str:

--- a/uobtheatre/utils/exceptions.py
+++ b/uobtheatre/utils/exceptions.py
@@ -19,6 +19,7 @@ from graphene.utils.str_converters import to_camel_case
 from graphene_django.types import ErrorType
 from sentry_sdk import capture_exception
 from square.core.api_error import ApiError
+from square.types.error import Error
 
 
 class ExceptionMiddleware:  # pragma: no cover
@@ -229,6 +230,30 @@ class SquareException(GQLException):
         passthrough_error_categories = [
             "PAYMENT_METHOD_ERROR",
         ]
+        # Turn common Square errors into user-friendly messages
+        user_readable_error_details = {
+            "ADDRESS_VERIFICATION_FAILURE": "The card issuer declined the request because the postal code is invalid.",
+            "CARD_EXPIRED": "The card issuer declined the request because the card is expired.",
+            "CVV_FAILURE": "The card issuer declined the request because the CVV value is invalid.",
+            "EXPIRATION_FAILURE": "The card expiration date is either invalid or indicates that the card is expired.",
+            "GENERIC_DECLINE": "Square received a decline without any additional information. If the payment information seems correct, contact your card issuer to ask for more information.",
+            "INSUFFICIENT_FUNDS": "The funding source has insufficient funds to cover the payment.",
+            "INVALID_EXPIRATION": "The expiration date for the payment card is invalid. For example, it indicates a date in the past.",
+            "INVALID_CARD": "The credit card cannot be validated based on the provided details.",
+            "INVALID_PHONE_NUMBER": "The provided phone number is invalid.",
+            "INVALID_PIN": "The card issuer declined the request because the PIN is invalid.",
+            "PAN_FAILURE": "The specified card number is invalid. For example, it is of incorrect length or is incorrectly formatted.",
+            "TRANSACTION_LIMIT": "The card issuer has determined the payment amount is either too high or too low.",
+            "BAD_EXPIRATION": "The card expiration date is either missing or incorrectly formatted.",
+            "CARD_DECLINED_VERIFICATION_REQUIRED": "The payment card was declined with a request for additional verification.",
+            "CHIP_INSERTION_REQUIRED": "The card issuer requires the card to be inserted into a chip reader."
+        }
+
+        def get_user_readable_error_message(error: Error) -> str:
+            if error.code in passthrough_error_categories:
+                return user_readable_error_details.get(error.code, "There was an issue processing your payment (%s)" % error.detail)
+            return error.detail
+
         error = (
             api_error.errors[0]
             if api_error.errors and len(api_error.errors)
@@ -236,7 +261,7 @@ class SquareException(GQLException):
         )
         message = (
             (
-                error.detail
+                get_user_readable_error_message(error)
                 if error.category in passthrough_error_categories
                 else "There was an issue processing your payment (%s)"
                 % error.code

--- a/uobtheatre/utils/test/test_exceptions.py
+++ b/uobtheatre/utils/test/test_exceptions.py
@@ -155,7 +155,11 @@ def test_square_exception():
     )
     assert len(exception.resolve()) == 1
     compare_gql_objects(
-        exception.resolve()[0], NonFieldError(message="There was an issue processing your payment (SOMETHING_WRONG)", code=400)
+        exception.resolve()[0],
+        NonFieldError(
+            message="There was an issue processing your payment (SOMETHING_WRONG)",
+            code=400,
+        ),
     )
 
 

--- a/uobtheatre/utils/test/test_exceptions.py
+++ b/uobtheatre/utils/test/test_exceptions.py
@@ -192,19 +192,19 @@ def test_square_exception_with_payment_method_error_no_detail():
     [
         (
             "ADDRESS_VERIFICATION_FAILURE",
-            "The card issuer declined the request because the postal code is invalid.",
+            "Your card details appear to be incorrect. Please check your details and try again.",
         ),
         (
             "CARD_EXPIRED",
-            "The card issuer declined the request because the card is expired.",
+            "Your card details appear to be incorrect. Please check your details and try again.",
         ),
         (
             "CVV_FAILURE",
-            "The card issuer declined the request because the CVV value is invalid.",
+            "Your card details appear to be incorrect. Please check your details and try again.",
         ),
         (
             "EXPIRATION_FAILURE",
-            "The card expiration date is either invalid or indicates that the card is expired.",
+            "Your card details appear to be incorrect. Please check your details and try again.",
         ),
         (
             "GENERIC_DECLINE",
@@ -216,20 +216,20 @@ def test_square_exception_with_payment_method_error_no_detail():
         ),
         (
             "INVALID_EXPIRATION",
-            "The expiration date for the payment card is invalid. For example, it indicates a date in the past.",
+            "Your card details appear to be incorrect. Please check your details and try again.",
         ),
         (
             "INVALID_CARD",
-            "The credit card cannot be validated based on the provided details.",
+            "Your card details appear to be incorrect. Please check your details and try again.",
         ),
         ("INVALID_PHONE_NUMBER", "The provided phone number is invalid."),
         (
             "INVALID_PIN",
-            "The card issuer declined the request because the PIN is invalid.",
+            "Your card details appear to be incorrect. Please check your details and try again.",
         ),
         (
             "PAN_FAILURE",
-            "The specified card number is invalid. For example, it is of incorrect length or is incorrectly formatted.",
+            "Your card details appear to be incorrect. Please check your details and try again.",
         ),
         (
             "TRANSACTION_LIMIT",
@@ -237,15 +237,15 @@ def test_square_exception_with_payment_method_error_no_detail():
         ),
         (
             "BAD_EXPIRATION",
-            "The card expiration date is either missing or incorrectly formatted.",
+            "Your card details appear to be incorrect. Please check your details and try again.",
         ),
         (
             "CARD_DECLINED_VERIFICATION_REQUIRED",
-            "The payment card was declined with a request for additional verification.",
+            "The payment card was declined with a request for additional verification Square cannot process.",
         ),
         (
             "CHIP_INSERTION_REQUIRED",
-            "The card issuer requires the card to be inserted into a chip reader.",
+            "The card issuer requires the card to be inserted into a chip reader, which Square cannot process.",
         ),
     ],
 )
@@ -253,12 +253,17 @@ def test_square_exception_user_readable_message(error_code, expected_message):
     exception = SquareException(
         ApiError(
             status_code=400,
-            body={"errors": [{"category": "PAYMENT_METHOD_ERROR", "code": error_code}]},
+            body={
+                "errors": [
+                    {"category": "PAYMENT_METHOD_ERROR", "code": error_code}
+                ]
+            },
         )
     )
     assert len(exception.resolve()) == 1
     compare_gql_objects(
-        exception.resolve()[0], NonFieldError(message=expected_message, code=400)
+        exception.resolve()[0],
+        NonFieldError(message=expected_message, code=400),
     )
 
 

--- a/uobtheatre/utils/test/test_exceptions.py
+++ b/uobtheatre/utils/test/test_exceptions.py
@@ -155,11 +155,11 @@ def test_square_exception():
     )
     assert len(exception.resolve()) == 1
     compare_gql_objects(
-        exception.resolve()[0], NonFieldError(message="Some phrase", code=400)
+        exception.resolve()[0], NonFieldError(message="There was an issue processing your payment (SOMETHING_WRONG)", code=400)
     )
 
 
-def test_square_exception_with_payment_method_error():
+def test_square_exception_with_payment_method_error_no_detail():
     exception = SquareException(
         ApiError(
             status_code=400,
@@ -168,7 +168,6 @@ def test_square_exception_with_payment_method_error():
                     {
                         "category": "PAYMENT_METHOD_ERROR",
                         "code": "SOMETHING_WRONG",
-                        "detail": "Detailed error message",
                     }
                 ]
             },
@@ -177,7 +176,85 @@ def test_square_exception_with_payment_method_error():
     assert len(exception.resolve()) == 1
     compare_gql_objects(
         exception.resolve()[0],
-        NonFieldError(message="Detailed error message", code=400),
+        NonFieldError(
+            message="There was an issue processing your payment (SOMETHING_WRONG)",
+            code=400,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "error_code, expected_message",
+    [
+        (
+            "ADDRESS_VERIFICATION_FAILURE",
+            "The card issuer declined the request because the postal code is invalid.",
+        ),
+        (
+            "CARD_EXPIRED",
+            "The card issuer declined the request because the card is expired.",
+        ),
+        (
+            "CVV_FAILURE",
+            "The card issuer declined the request because the CVV value is invalid.",
+        ),
+        (
+            "EXPIRATION_FAILURE",
+            "The card expiration date is either invalid or indicates that the card is expired.",
+        ),
+        (
+            "GENERIC_DECLINE",
+            "Square received a decline without any additional information. If the payment information seems correct, contact your card issuer to ask for more information.",
+        ),
+        (
+            "INSUFFICIENT_FUNDS",
+            "The funding source has insufficient funds to cover the payment.",
+        ),
+        (
+            "INVALID_EXPIRATION",
+            "The expiration date for the payment card is invalid. For example, it indicates a date in the past.",
+        ),
+        (
+            "INVALID_CARD",
+            "The credit card cannot be validated based on the provided details.",
+        ),
+        ("INVALID_PHONE_NUMBER", "The provided phone number is invalid."),
+        (
+            "INVALID_PIN",
+            "The card issuer declined the request because the PIN is invalid.",
+        ),
+        (
+            "PAN_FAILURE",
+            "The specified card number is invalid. For example, it is of incorrect length or is incorrectly formatted.",
+        ),
+        (
+            "TRANSACTION_LIMIT",
+            "The card issuer has determined the payment amount is either too high or too low.",
+        ),
+        (
+            "BAD_EXPIRATION",
+            "The card expiration date is either missing or incorrectly formatted.",
+        ),
+        (
+            "CARD_DECLINED_VERIFICATION_REQUIRED",
+            "The payment card was declined with a request for additional verification.",
+        ),
+        (
+            "CHIP_INSERTION_REQUIRED",
+            "The card issuer requires the card to be inserted into a chip reader.",
+        ),
+    ],
+)
+def test_square_exception_user_readable_message(error_code, expected_message):
+    exception = SquareException(
+        ApiError(
+            status_code=400,
+            body={"errors": [{"category": "PAYMENT_METHOD_ERROR", "code": error_code}]},
+        )
+    )
+    assert len(exception.resolve()) == 1
+    compare_gql_objects(
+        exception.resolve()[0], NonFieldError(message=expected_message, code=400)
     )
 
 


### PR DESCRIPTION
Adds a short handler to humanise Square API Error Messages for end users, as error details are [not intended to be customer facing](https://developer.squareup.com/docs/build-basics/general-considerations/handling-errors#error-object-properties). This covers the [error codes](https://developer.squareup.com/reference/square/payments-api/create-payment) we are likely to face when attempting to create payments, and otherwise falls back to using the error code. 

Adds tests to keep that sweet, sweet 100% coverage!