### PR TITLE
fix: Only send emails when there is actually accessibility info.

### DIFF
--- a/uobtheatre/bookings/models.py
+++ b/uobtheatre/bookings/models.py
@@ -586,7 +586,10 @@ class Booking(TimeStampedMixin, Payable):
         super().complete()
 
         booking_emails.send_booking_confirmation_email(self, payment)
-        if self.accessibility_info and len(self.accessibility_info.strip()) > 4:
+        if (
+            self.accessibility_info
+            and len(self.accessibility_info.strip()) > 4
+        ):
             booking_emails.send_booking_accessibility_info_email(self)
 
     def clone(self):

--- a/uobtheatre/bookings/models.py
+++ b/uobtheatre/bookings/models.py
@@ -586,7 +586,7 @@ class Booking(TimeStampedMixin, Payable):
         super().complete()
 
         booking_emails.send_booking_confirmation_email(self, payment)
-        if self.accessibility_info:
+        if self.accessibility_info and len(self.accessibility_info.strip()) > 4:
             booking_emails.send_booking_accessibility_info_email(self)
 
     def clone(self):

--- a/uobtheatre/bookings/mutations.py
+++ b/uobtheatre/bookings/mutations.py
@@ -166,7 +166,8 @@ class UpdateBookingAccessibilityInfo(AuthRequiredMixin, SafeMutation):
 
         if previous_accessibility_info and not accessibility_info:
             booking_emails.send_booking_accessibility_removed_email(booking)
-        elif accessibility_info and not previous_accessibility_info and len(accessibility_info.strip()) > 4:
+        elif (accessibility_info and not previous_accessibility_info 
+            and len(accessibility_info.strip()) > 4):
             booking_emails.send_booking_accessibility_info_email(booking)
         elif previous_accessibility_info and (
             accessibility_info != previous_accessibility_info

--- a/uobtheatre/bookings/mutations.py
+++ b/uobtheatre/bookings/mutations.py
@@ -166,11 +166,11 @@ class UpdateBookingAccessibilityInfo(AuthRequiredMixin, SafeMutation):
 
         if previous_accessibility_info and not accessibility_info:
             booking_emails.send_booking_accessibility_removed_email(booking)
-        elif accessibility_info and not previous_accessibility_info:
+        elif accessibility_info and not previous_accessibility_info and len(accessibility_info.strip()) > 4::
             booking_emails.send_booking_accessibility_info_email(booking)
         elif previous_accessibility_info and (
             accessibility_info != previous_accessibility_info
-        ):
+        ) and len(accessibility_info.strip()) > 4::
             booking_emails.send_booking_accessibility_updated_email(booking)
 
         return cls(success=True)

--- a/uobtheatre/bookings/mutations.py
+++ b/uobtheatre/bookings/mutations.py
@@ -166,7 +166,7 @@ class UpdateBookingAccessibilityInfo(AuthRequiredMixin, SafeMutation):
 
         if previous_accessibility_info and not accessibility_info:
             booking_emails.send_booking_accessibility_removed_email(booking)
-        elif accessibility_info and not previous_accessibility_info and len(accessibility_info.strip()) > 4::
+        elif accessibility_info and not previous_accessibility_info and len(accessibility_info.strip()) > 4:
             booking_emails.send_booking_accessibility_info_email(booking)
         elif previous_accessibility_info and (
             accessibility_info != previous_accessibility_info

--- a/uobtheatre/bookings/mutations.py
+++ b/uobtheatre/bookings/mutations.py
@@ -166,12 +166,17 @@ class UpdateBookingAccessibilityInfo(AuthRequiredMixin, SafeMutation):
 
         if previous_accessibility_info and not accessibility_info:
             booking_emails.send_booking_accessibility_removed_email(booking)
-        elif (accessibility_info and not previous_accessibility_info 
-            and len(accessibility_info.strip()) > 4):
+        elif (
+            accessibility_info
+            and not previous_accessibility_info
+            and len(accessibility_info.strip()) > 4
+        ):
             booking_emails.send_booking_accessibility_info_email(booking)
-        elif previous_accessibility_info and (
-            accessibility_info != previous_accessibility_info
-        ) and len(accessibility_info.strip()) > 4:
+        elif (
+            previous_accessibility_info
+            and (accessibility_info != previous_accessibility_info)
+            and len(accessibility_info.strip()) > 4
+        ):
             booking_emails.send_booking_accessibility_updated_email(booking)
 
         return cls(success=True)

--- a/uobtheatre/bookings/mutations.py
+++ b/uobtheatre/bookings/mutations.py
@@ -170,7 +170,7 @@ class UpdateBookingAccessibilityInfo(AuthRequiredMixin, SafeMutation):
             booking_emails.send_booking_accessibility_info_email(booking)
         elif previous_accessibility_info and (
             accessibility_info != previous_accessibility_info
-        ) and len(accessibility_info.strip()) > 4::
+        ) and len(accessibility_info.strip()) > 4:
             booking_emails.send_booking_accessibility_updated_email(booking)
 
         return cls(success=True)


### PR DESCRIPTION
Often, users put 'No' or similar when they don't have accessibility requirements. This check will prevent emails being sent for accessibility infos with four or less characters.