### PR TITLE
feat: allow bristolsta.com to get production information

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -8,6 +8,8 @@ SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")  # type: ignore
 CORS_ALLOWED_ORIGINS = [
     "https://uobtheatre.com",
     "https://staging.uobtheatre.com",
+    "https://bristolsta.com",
+    "https://staging.bristolsta.com",
 ]
 
 # Site


### PR DESCRIPTION
Adds (staging.)bristolsta.com to the domains allowed to make cross-origin requests for production information needed for the "What's On" page.